### PR TITLE
Improve appearence of conversation folder badges

### DIFF
--- a/files/style/conversation.less
+++ b/files/style/conversation.less
@@ -76,6 +76,10 @@
 	}
 }
 
+.conversationFolderList > li > a > span {
+	float: right;
+}
+
 @media only screen and (max-width: 800px) {
 	.conversationList {
 		thead {

--- a/templates/conversationList.tpl
+++ b/templates/conversationList.tpl
@@ -54,7 +54,7 @@
 		<legend>{lang}wcf.conversation.folders{/lang}</legend>
 		
 		<nav>
-			<ul>
+			<ul class="conversationFolderList">
 				<li{if $filter == ''} class="active"{/if}><a href="{link controller='ConversationList'}{/link}">{lang}wcf.conversation.conversations{/lang}{if $conversationCount} <span class="badge">{#$conversationCount}</span>{/if}</a></li>
 				<li{if $filter == 'draft'} class="active"{/if}><a href="{link controller='ConversationList'}filter=draft{/link}">{lang}wcf.conversation.folder.draft{/lang}{if $draftCount} <span class="badge">{#$draftCount}</span>{/if}</a></li>
 				<li{if $filter == 'outbox'} class="active"{/if}><a href="{link controller='ConversationList'}filter=outbox{/link}">{lang}wcf.conversation.folder.outbox{/lang}{if $outboxCount} <span class="badge">{#$outboxCount}</span>{/if}</a></li>


### PR DESCRIPTION
This would improve the appearence of the conversation folder badges.

Before:
![before](https://cloud.githubusercontent.com/assets/7986618/9245227/7579a992-41a2-11e5-8264-81fb61739d4a.png)

After:
![after](https://cloud.githubusercontent.com/assets/7986618/9245230/845f110e-41a2-11e5-8e07-d8dfa4fd9a76.png)
