### PR TITLE
ending dot/period for package description...

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package name="com.woltlab.wcf.conversation" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/package.xsd">
 	<packageinformation>
 		<packagename>User Conversation System</packagename>
-		<packagedescription>Private conversations between multiple users</packagedescription>
+		<packagedescription>Private conversations between multiple users.</packagedescription>
 		<version>2.1.6</version>
 		<date>2016-06-01</date>
 	</packageinformation>


### PR DESCRIPTION
all other products have it, except conversation and infraction.