### PR TITLE
Add possibility to mark a conversation as read for the non active user

### DIFF
--- a/files/lib/data/conversation/Conversation.class.php
+++ b/files/lib/data/conversation/Conversation.class.php
@@ -292,7 +292,7 @@ class Conversation extends DatabaseObject implements IRouteController, ITitledLi
 	public function getParticipants($excludeSelf = false) {
 		$conditions = new PreparedStatementConditionBuilder();
 		$conditions->add("conversationID = ?", [$this->conversationID]);
-		if ($excludeSelf) $conditions->add("conversation_to_user.participantID <> ?", [WCF::getUser()->userID]);
+		if ($excludeSelf) $conditions->add("participantID <> ?", [WCF::getUser()->userID]);
 		
 		$sql = "SELECT		participantID
 			FROM		wcf".WCF_N."_conversation_to_user

--- a/files/lib/data/conversation/ConversationAction.class.php
+++ b/files/lib/data/conversation/ConversationAction.class.php
@@ -217,7 +217,8 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 			$this->parameters['visitTime'] = TIME_NOW;
 		}
 
-		if (!isset($this->parameters['userID'])) {
+		// userID cannot be set during an AJAX request, but only when calling this method within PHP
+		if (!array_key_exists('userID', $this->parameters)) {
 			$this->parameters['userID'] = WCF::getUser()->userID;
 		}
 		
@@ -314,6 +315,8 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 				$this->parameters['visitTime'] = TIME_NOW;
 			}
 		}
+
+		unset($this->parameters['userID']);
 		
 		if (empty($this->objects)) {
 			$this->readObjects();

--- a/files/lib/data/conversation/ConversationAction.class.php
+++ b/files/lib/data/conversation/ConversationAction.class.php
@@ -216,6 +216,10 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 		if (empty($this->parameters['visitTime'])) {
 			$this->parameters['visitTime'] = TIME_NOW;
 		}
+
+		if (!isset($this->parameters['userID'])) {
+			$this->parameters['userID'] = WCF::getUser()->userID;
+		}
 		
 		if (empty($this->objects)) {
 			$this->readObjects();
@@ -231,7 +235,7 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 		foreach ($this->getObjects() as $conversation) {
 			$statement->execute([
 				$this->parameters['visitTime'],
-				WCF::getUser()->userID,
+				$this->parameters['userID'],
 				$conversation->conversationID
 			]);
 			$conversationIDs[] = $conversation->conversationID;
@@ -239,7 +243,7 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 		WCF::getDB()->commitTransaction();
 		
 		// reset storage
-		UserStorageHandler::getInstance()->reset([WCF::getUser()->userID], 'unreadConversationCount');
+		UserStorageHandler::getInstance()->reset([$this->parameters['userID']], 'unreadConversationCount');
 		
 		// mark notifications as confirmed
 		if (!empty($conversationIDs)) {
@@ -247,7 +251,7 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 			$conditionBuilder = new PreparedStatementConditionBuilder();
 			$conditionBuilder->add('notification.eventID = ?', [UserNotificationHandler::getInstance()->getEvent('com.woltlab.wcf.conversation.notification', 'conversation')->eventID]);
 			$conditionBuilder->add('notification.objectID = conversation.conversationID');
-			$conditionBuilder->add('notification.userID = ?', [WCF::getUser()->userID]);
+			$conditionBuilder->add('notification.userID = ?', [$this->parameters['userID']]);
 			$conditionBuilder->add('conversation.conversationID IN (?)', [$conversationIDs]);
 			$conditionBuilder->add('conversation.time <= ?', [$this->parameters['visitTime']]);
 			
@@ -260,14 +264,14 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 			$notificationObjectIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
 			
 			if (!empty($notificationObjectIDs)) {
-				UserNotificationHandler::getInstance()->markAsConfirmed('conversation', 'com.woltlab.wcf.conversation.notification', [WCF::getUser()->userID], $notificationObjectIDs);
+				UserNotificationHandler::getInstance()->markAsConfirmed('conversation', 'com.woltlab.wcf.conversation.notification', [$this->parameters['userID']], $notificationObjectIDs);
 			}
 			
 			// conversation reply notification
 			$conditionBuilder = new PreparedStatementConditionBuilder();
 			$conditionBuilder->add('notification.eventID = ?', [UserNotificationHandler::getInstance()->getEvent('com.woltlab.wcf.conversation.message.notification', 'conversationMessage')->eventID]);
 			$conditionBuilder->add('notification.objectID = conversation_message.messageID');
-			$conditionBuilder->add('notification.userID = ?', [WCF::getUser()->userID]);
+			$conditionBuilder->add('notification.userID = ?', [$this->parameters['userID']]);
 			$conditionBuilder->add('conversation_message.conversationID IN (?)', [$conversationIDs]);
 			$conditionBuilder->add('conversation_message.time <= ?', [$this->parameters['visitTime']]);
 			
@@ -280,7 +284,7 @@ class ConversationAction extends AbstractDatabaseObjectAction implements IClipbo
 			$notificationObjectIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
 			
 			if (!empty($notificationObjectIDs)) {
-				UserNotificationHandler::getInstance()->markAsConfirmed('conversationMessage', 'com.woltlab.wcf.conversation.message.notification', [WCF::getUser()->userID], $notificationObjectIDs);
+				UserNotificationHandler::getInstance()->markAsConfirmed('conversationMessage', 'com.woltlab.wcf.conversation.message.notification', [$this->parameters['userID']], $notificationObjectIDs);
 			}
 		}
 		


### PR DESCRIPTION
There is currently no possibility to mark conversations as read for another user, which is not logged in (except for copying all the code).
This can be necessary when importing old conversations and you do not want them marked as new ones.