### PR TITLE
Basic flood control for started conversations

### DIFF
--- a/files/lib/form/ConversationAddForm.class.php
+++ b/files/lib/form/ConversationAddForm.class.php
@@ -97,6 +97,8 @@ class ConversationAddForm extends MessageForm {
 			throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.conversation.error.mailboxIsFull'));
 		}
 		
+		ConversationHandler::getInstance()->enforceFloodControl();
+		
 		if (isset($_REQUEST['userID'])) {
 			$userID = intval($_REQUEST['userID']);
 			$user = UserProfileRuntimeCache::getInstance()->getObject($userID);

--- a/files/lib/system/conversation/ConversationHandler.class.php
+++ b/files/lib/system/conversation/ConversationHandler.class.php
@@ -129,7 +129,7 @@ class ConversationHandler extends SingletonFactory {
 	 */
 	public function enforceFloodControl() {
 		$limit = WCF::getSession()->getPermission('user.conversation.maxStartedConversationsPer24Hours');
-		if ($limit < 1) {
+		if ($limit == -1) {
 			return;
 		}
 		

--- a/language/de.xml
+++ b/language/de.xml
@@ -22,6 +22,8 @@
 		<item name="wcf.acp.group.option.user.conversation.maxAttachmentCount.description"><![CDATA[]]></item>
 		<item name="wcf.acp.group.option.user.conversation.canEditMessage"><![CDATA[Kann eigene Nachrichten bearbeiten]]></item>
 		<item name="wcf.acp.group.option.user.conversation.canEditMessage.description"><![CDATA[Mitglieder dieser Benutzergruppe können eigene Nachrichten in Konversationen nachträglich verändern, auch wenn diese bereits vom Empfänger gelesen wurden.]]></item>
+		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours"><![CDATA[Maximale Anzahl gestarteter Konversation innerhalb von 24 Stunden]]></item>
+		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours.description"><![CDATA[Beschränkt die Anzahl der Konversationen die ein Benutzer innerhalb von 24 Stunden starten darf. [-1 für unbegrenzt]]]></item>
 	</category>
 	
 	<category name="wcf.acp.option">
@@ -124,6 +126,7 @@
 		<item name="wcf.conversation.noParticipantsWarning"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du bist{else}Sie sind{/if} dabei, auf eine Konversation ohne weitere Teilnehmer zu antworten. Alle anderen Teilnehmer haben diese Konversation verlassen. Niemand wird {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} Nachricht lesen!]]></item>
 		<item name="wcf.conversation.message.permalink"><![CDATA[Permalink zur {#$startIndex}. Nachricht]]></item>
 		<item name="wcf.conversation.markAsRead.doubleClick"><![CDATA[Konversation durch Doppelklick als gelesen markieren]]></item>
+		<item name="wcf.conversation.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} innerhalb der letzten 24 Stunden bereits {if $limit == 1}eine Konversation{else}{#$limit} Konversationen{/if} gestartet. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}warte{else}warten Sie{/if} bis zum <strong>{@$notBefore|time}</strong>, bevor {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} eine neue Konversation {if LANGUAGE_USE_INFORMAL_VARIANT}startest{else}starten{/if}.]]></item>
 	</category>
 	
 	<category name="wcf.conversation.edit">

--- a/language/en.xml
+++ b/language/en.xml
@@ -22,6 +22,8 @@
 		<item name="wcf.acp.group.option.user.conversation.maxAttachmentCount.description"><![CDATA[The maximum number of attachments allowed per message.]]></item>
 		<item name="wcf.acp.group.option.user.conversation.canEditMessage"><![CDATA[Can edit their messages]]></item>
 		<item name="wcf.acp.group.option.user.conversation.canEditMessage.description"><![CDATA[Users can edit their messages, regardless if they have been read by one or more recipients.]]></item>
+		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours"><![CDATA[Maximum Number of Started Conversations per 24 Hours]]></item>
+		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours.description"><![CDATA[Limits the number of conversations that a user can start within 24 hours. Use -1 for infinite.]]></item>
 	</category>
 	
 	<category name="wcf.acp.option">
@@ -124,6 +126,7 @@
 		<item name="wcf.conversation.noParticipantsWarning"><![CDATA[You are about to reply to a conversation without other participants, nobody is going to read your message!]]></item>
 		<item name="wcf.conversation.message.permalink"><![CDATA[Permalink to {#$startIndex}. message]]></item>
 		<item name="wcf.conversation.markAsRead.doubleClick"><![CDATA[Double-Click to Mark This Conversation Read]]></item>
+		<item name="wcf.conversation.error.floodControl"><![CDATA[You have already started {if $limit == 1}one conversation{else}{#$limit} conversations{/if} in the past 24 hours. Please wait until <strong>{@$notBefore|time}</strong> before you start a new conversation.]]></item>
 	</category>
 	
 	<category name="wcf.conversation.edit">

--- a/userGroupOption.xml
+++ b/userGroupOption.xml
@@ -62,6 +62,14 @@
 				<maxvalue>100000</maxvalue>
 				<usersonly>1</usersonly>
 			</option>
+			<option name="user.conversation.maxStartedConversationsPer24Hours">
+				<categoryname>user.conversation</categoryname>
+				<optiontype>infiniteInteger</optiontype>
+				<defaultvalue>10</defaultvalue>
+				<admindefaultvalue>-1</admindefaultvalue>
+				<minvalue>-1</minvalue>
+				<usersonly>1</usersonly>
+			</option>
 			<option name="user.conversation.maxLabels">
 				<categoryname>user.conversation</categoryname>
 				<optiontype>integer</optiontype>


### PR DESCRIPTION
Implements a basic flood control by limiting the amount of started conversations per user within a rolling 24 hour period.