### PR TITLE
Add flood control for conversation messages

### DIFF
--- a/files/lib/form/ConversationAddForm.class.php
+++ b/files/lib/form/ConversationAddForm.class.php
@@ -121,7 +121,7 @@ class ConversationAddForm extends MessageForm
             ));
         }
 
-        ConversationHandler::getInstance()->enforceFloodControl();
+        ConversationHandler::getInstance()->enforceFloodControl(false);
 
         if (isset($_REQUEST['userID'])) {
             $userID = \intval($_REQUEST['userID']);
@@ -300,6 +300,7 @@ class ConversationAddForm extends MessageForm
         MessageQuoteManager::getInstance()->saved();
 
         FloodControl::getInstance()->registerContent('com.woltlab.wcf.conversation');
+        FloodControl::getInstance()->registerContent('com.woltlab.wcf.conversation.message');
 
         $this->saved();
 

--- a/language/de.xml
+++ b/language/de.xml
@@ -34,6 +34,8 @@
 		<item name="wcf.acp.group.canBeAddedAsConversationParticipant"><![CDATA[Benutzergruppe kann als Teilnehmer in Konversationen hinzufügt werden]]></item>
 		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours"><![CDATA[Maximale Anzahl gestarteter Konversation innerhalb von 24 Stunden]]></item>
 		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours.description"><![CDATA[Beschränkt die Anzahl der Konversationen die ein Benutzer innerhalb von 24 Stunden starten darf. [-1 für unbegrenzt]]]></item>
+		<item name="wcf.acp.group.option.user.conversation.floodControlTime"><![CDATA[Mindestzeit zwischen zwei Nachrichten]]></item>
+		<item name="wcf.acp.group.option.user.conversation.floodControlTime.description"><![CDATA[Mindestzeit, die zwischen zwei hintereinander folgenden Konversationsnachrichten vergehen muss. [0 für unbeschränkt]]]></item>
 	</category>
 	<category name="wcf.acp.option">
 		<item name="wcf.acp.option.category.message.conversation"><![CDATA[Konversationen]]></item>

--- a/language/de.xml
+++ b/language/de.xml
@@ -142,6 +142,7 @@
 		<item name="wcf.conversation.time"><![CDATA[Erstellung]]></item>
 		<item name="wcf.conversation.username"><![CDATA[Autor]]></item>
 		<item name="wcf.conversation.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} innerhalb der letzten 24 Stunden bereits {if $limit == 1}eine Konversation{else}{#$limit} Konversationen{/if} gestartet. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}warte{else}warten Sie{/if} bis zum <strong>{@$notBefore|time}</strong>, bevor {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} eine neue Konversation {if LANGUAGE_USE_INFORMAL_VARIANT}startest{else}starten{/if}.]]></item>
+		<item name="wcf.conversation.message.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} bereits eine Nachricht innerhalb der letzten {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='Sekunde' other='# Sekunden'} versendet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if} erst in {plural value=$waitTime 1='Sekunde' other='# Sekunden'} eine neue Nachricht verfassen.]]></item>
 	</category>
 	<category name="wcf.conversation.edit">
 		<item name="wcf.conversation.edit.addParticipants"><![CDATA[Teilnehmer hinzufügen]]></item>

--- a/language/de.xml
+++ b/language/de.xml
@@ -142,7 +142,7 @@
 		<item name="wcf.conversation.time"><![CDATA[Erstellung]]></item>
 		<item name="wcf.conversation.username"><![CDATA[Autor]]></item>
 		<item name="wcf.conversation.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} innerhalb der letzten 24 Stunden bereits {if $limit == 1}eine Konversation{else}{#$limit} Konversationen{/if} gestartet. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}warte{else}warten Sie{/if} bis zum <strong>{@$notBefore|time}</strong>, bevor {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} eine neue Konversation {if LANGUAGE_USE_INFORMAL_VARIANT}startest{else}starten{/if}.]]></item>
-		<item name="wcf.conversation.message.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} bereits eine Nachricht innerhalb der letzten {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='Sekunde' other='# Sekunden'} versendet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if} erst in {plural value=$waitTime 1='Sekunde' other='# Sekunden'} eine neue Nachricht verfassen.]]></item>
+		<item name="wcf.conversation.message.error.floodControl"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} bereits eine Nachricht innerhalb der letzten {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='Sekunde' other='# Sekunden'} versendet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if} erst in {plural value=$waitTime 1='einer Sekunde' other='# Sekunden'} eine neue Nachricht verfassen.]]></item>
 	</category>
 	<category name="wcf.conversation.edit">
 		<item name="wcf.conversation.edit.addParticipants"><![CDATA[Teilnehmer hinzufügen]]></item>

--- a/language/en.xml
+++ b/language/en.xml
@@ -142,6 +142,7 @@
 		<item name="wcf.conversation.time"><![CDATA[Creation]]></item>
 		<item name="wcf.conversation.username"><![CDATA[Author]]></item>
 		<item name="wcf.conversation.error.floodControl"><![CDATA[You have already started {if $limit == 1}one conversation{else}{#$limit} conversations{/if} in the past 24 hours. Please wait until <strong>{@$notBefore|time}</strong> before you start a new conversation.]]></item>
+		<item name="wcf.conversation.message.error.floodControl"><![CDATA[You have already sent a message within the last {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='second' other='# seconds'}. You must wait at least {plural value=$waitTime 1='second' other='# seconds'} before attempting to write a new message.]]></item>
 	</category>
 	<category name="wcf.conversation.edit">
 		<item name="wcf.conversation.edit.addParticipants"><![CDATA[Add Participants]]></item>

--- a/language/en.xml
+++ b/language/en.xml
@@ -142,7 +142,7 @@
 		<item name="wcf.conversation.time"><![CDATA[Creation]]></item>
 		<item name="wcf.conversation.username"><![CDATA[Author]]></item>
 		<item name="wcf.conversation.error.floodControl"><![CDATA[You have already started {if $limit == 1}one conversation{else}{#$limit} conversations{/if} in the past 24 hours. Please wait until <strong>{@$notBefore|time}</strong> before you start a new conversation.]]></item>
-		<item name="wcf.conversation.message.error.floodControl"><![CDATA[You have already sent a message within the last {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='second' other='# seconds'}. You must wait at least {plural value=$waitTime 1='second' other='# seconds'} before attempting to write a new message.]]></item>
+		<item name="wcf.conversation.message.error.floodControl"><![CDATA[You have already sent a message within the last {plural value=$__wcf->getSession()->getPermission('user.conversation.floodControlTime') 1='second' other='# seconds'}. You must wait at least {plural value=$waitTime 1='one second' other='# seconds'} before attempting to write a new message.]]></item>
 	</category>
 	<category name="wcf.conversation.edit">
 		<item name="wcf.conversation.edit.addParticipants"><![CDATA[Add Participants]]></item>

--- a/language/en.xml
+++ b/language/en.xml
@@ -34,6 +34,8 @@
 		<item name="wcf.acp.group.canBeAddedAsConversationParticipant"><![CDATA[User group can be added as participant in conversations]]></item>
 		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours"><![CDATA[Maximum Number of Started Conversations per 24 Hours]]></item>
 		<item name="wcf.acp.group.option.user.conversation.maxStartedConversationsPer24Hours.description"><![CDATA[Limits the number of conversations that a user can start within 24 hours. Use -1 for infinite.]]></item>
+		<item name="wcf.acp.group.option.user.conversation.floodControlTime"><![CDATA[Delay for Messages]]></item>
+		<item name="wcf.acp.group.option.user.conversation.floodControlTime.description"><![CDATA[Seconds required between creating two conversation messages. Use 0 to disable.]]></item>
 	</category>
 	<category name="wcf.acp.option">
 		<item name="wcf.acp.option.category.message.conversation"><![CDATA[Conversations]]></item>

--- a/objectType.xml
+++ b/objectType.xml
@@ -121,5 +121,9 @@
 			<name>com.woltlab.wcf.conversation</name>
 			<definitionname>com.woltlab.wcf.floodControl</definitionname>
 		</type>
+		<type>
+			<name>com.woltlab.wcf.conversation.message</name>
+			<definitionname>com.woltlab.wcf.floodControl</definitionname>
+		</type>
 	</import>
 </data>

--- a/userGroupOption.xml
+++ b/userGroupOption.xml
@@ -76,7 +76,6 @@
 				<usersonly>1</usersonly>
 				<admindefaultvalue>1</admindefaultvalue>
 			</option>
-			
 			<option name="user.conversation.maxParticipants">
 				<categoryname>user.conversation</categoryname>
 				<optiontype>integer</optiontype>
@@ -91,6 +90,15 @@
 				<defaultvalue>100</defaultvalue>
 				<minvalue>1</minvalue>
 				<maxvalue>100000</maxvalue>
+				<usersonly>1</usersonly>
+			</option>
+			<option name="user.conversation.floodControlTime">
+				<categoryname>user.conversation</categoryname>
+				<optiontype>inverseInteger</optiontype>
+				<defaultvalue>60</defaultvalue>
+				<minvalue>0</minvalue>
+				<suffix>seconds</suffix>
+				<admindefaultvalue>0</admindefaultvalue>
 				<usersonly>1</usersonly>
 			</option>
 			<option name="user.conversation.maxStartedConversationsPer24Hours">


### PR DESCRIPTION
- Add user.conversation.floodControlTime
- Add com.woltlab.wcf.conversation.message object type to flood control
- Enforce `user.conversation.floodControlTime`
