### PR TITLE
Prevent method calls on `null` in ConversationMessageAttachmentObjectType::canDownload()

### DIFF
--- a/files/lib/system/attachment/ConversationMessageAttachmentObjectType.class.php
+++ b/files/lib/system/attachment/ConversationMessageAttachmentObjectType.class.php
@@ -55,7 +55,7 @@ class ConversationMessageAttachmentObjectType extends AbstractAttachmentObjectTy
         if ($objectID) {
             $message = new ConversationMessage($objectID);
             $conversation = Conversation::getUserConversation($message->conversationID, WCF::getUser()->userID);
-            if ($conversation->canRead()) {
+            if ($conversation !== null && $conversation->canRead()) {
                 return true;
             }
         }


### PR DESCRIPTION
This may happen for attachments where the corresponding conversation /
conversation message no longer exists.

-----------------------

Shall we add an update script that cleans up orphaned attachments?
