### PR TITLE
Add ConversationMessageSearchIndexRebuildDataWorker

### DIFF
--- a/files/lib/system/worker/ConversationMessageRebuildDataWorker.class.php
+++ b/files/lib/system/worker/ConversationMessageRebuildDataWorker.class.php
@@ -7,7 +7,6 @@ use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\bbcode\BBCodeHandler;
 use wcf\system\html\input\HtmlInputProcessor;
 use wcf\system\message\embedded\object\MessageEmbeddedObjectManager;
-use wcf\system\search\SearchIndexManager;
 use wcf\system\WCF;
 
 /**
@@ -76,11 +75,6 @@ class ConversationMessageRebuildDataWorker extends AbstractRebuildDataWorker
 
         parent::execute();
 
-        if (!$this->loopCount) {
-            // reset search index
-            SearchIndexManager::getInstance()->reset('com.woltlab.wcf.conversation.message');
-        }
-
         if (!\count($this->objectList)) {
             return;
         }
@@ -104,16 +98,6 @@ class ConversationMessageRebuildDataWorker extends AbstractRebuildDataWorker
 
         $updateData = [];
         foreach ($this->getObjectList() as $message) {
-            SearchIndexManager::getInstance()->set(
-                'com.woltlab.wcf.conversation.message',
-                $message->messageID,
-                $message->message,
-                $message->subject ?: '',
-                $message->time,
-                $message->userID,
-                $message->username
-            );
-
             $data = [];
 
             // count attachments

--- a/files/lib/system/worker/ConversationMessageSearchIndexRebuildDataWorker.class.php
+++ b/files/lib/system/worker/ConversationMessageSearchIndexRebuildDataWorker.class.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace wcf\system\worker;
+
+use wcf\data\conversation\ConversationList;
+use wcf\data\conversation\message\ConversationMessageList;
+use wcf\system\search\SearchIndexManager;
+use wcf\system\WCF;
+
+/**
+ * Worker implementation for updating the search index of conversation messages.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2019 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Worker
+ *
+ * @method  ConversationMessageList     getObjectList()
+ */
+final class ConversationMessageSearchIndexRebuildDataWorker extends AbstractRebuildDataWorker
+{
+    /**
+     * @inheritDoc
+     */
+    protected $limit = 1000;
+
+    /**
+     * @inheritDoc
+     */
+    public function countObjects()
+    {
+        if ($this->count === null) {
+            $this->count = 0;
+            $sql = "SELECT  MAX(messageID) AS messageID
+                    FROM    wcf" . WCF_N . "_conversation_message";
+            $statement = WCF::getDB()->prepareStatement($sql);
+            $statement->execute();
+            $row = $statement->fetchArray();
+            if ($row !== false) {
+                $this->count = $row['messageID'];
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function initObjectList()
+    {
+        $this->objectList = new ConversationMessageList();
+        $this->objectList->sqlOrderBy = 'conversation_message.messageID';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute()
+    {
+        $this->objectList->getConditionBuilder()->add(
+            'conversation_message.messageID BETWEEN ? AND ?',
+            [$this->limit * $this->loopCount + 1, $this->limit * $this->loopCount + $this->limit]
+        );
+
+        parent::execute();
+
+        if (!$this->loopCount) {
+            // reset search index
+            SearchIndexManager::getInstance()->reset('com.woltlab.wcf.conversation.message');
+        }
+
+        if (!\count($this->objectList)) {
+            return;
+        }
+
+        // read associated conversations
+        $conversationIDs = \array_column(
+            $this->getObjectList()->getObjects(),
+            'conversationID'
+        );
+
+        $threadList = new ConversationList();
+        $threadList->setObjectIDs($conversationIDs);
+        $threadList->readObjects();
+        $conversations = $threadList->getObjects();
+
+        foreach ($this->getObjectList() as $message) {
+            $message->setConversation($conversations[$message->conversationID]);
+
+            $subject = '';
+            if ($message->messageID == $message->getConversation()->firstMessageID) {
+                $subject = $message->getTitle();
+            }
+
+            SearchIndexManager::getInstance()->set(
+                'com.woltlab.wcf.conversation.message',
+                $message->messageID,
+                $message->message,
+                $subject,
+                $message->time,
+                $message->userID,
+                $message->username
+            );
+        }
+    }
+}

--- a/language/de.xml
+++ b/language/de.xml
@@ -51,7 +51,9 @@
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation"><![CDATA[Konversationen aktualisieren]]></item>
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.description"><![CDATA[Aktualisiert Zähler der Konversationen]]></item>
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message"><![CDATA[Konversationsnachrichten aktualisieren]]></item>
-		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.description"><![CDATA[Aktualisiert den Suchindex für Konversationsnachrichten]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.description"><![CDATA[Aktualisiert Zähler der Konversationsnachrichten]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.search.index"><![CDATA[Suchindex für Konversationsnachrichten aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.search.index.description"><![CDATA[Warnung: Die Ausführung dieser Aktion kann bei größeren Foren sehr lange dauern.]]></item>
 	</category>
 	<category name="wcf.acp.stat">
 		<item name="wcf.acp.stat.com.woltlab.wcf.conversation"><![CDATA[Konversationen]]></item>

--- a/language/en.xml
+++ b/language/en.xml
@@ -51,7 +51,9 @@
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation"><![CDATA[Rebuild Conversations]]></item>
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.description"><![CDATA[Rebuilds the conversation counters.]]></item>
 		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message"><![CDATA[Rebuild Conversation Messages]]></item>
-		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.description"><![CDATA[Rebuilds the search index for the conversation messages.]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.description"><![CDATA[Rebuilds the conversation message counters.]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.search.index"><![CDATA[Rebuild Conversation Message Search Index]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.conversation.message.search.index.description"><![CDATA[Warning: This action can take a while to complete on large forums.]]></item>
 	</category>
 	<category name="wcf.acp.stat">
 		<item name="wcf.acp.stat.com.woltlab.wcf.conversation"><![CDATA[Conversations]]></item>

--- a/objectType.xml
+++ b/objectType.xml
@@ -90,6 +90,12 @@
 			<classname>wcf\system\worker\ConversationMessageRebuildDataWorker</classname>
 			<nicevalue>-5</nicevalue>
 		</type>
+		<type>
+			<name>com.woltlab.wcf.conversation.message.search.index</name>
+			<definitionname>com.woltlab.wcf.rebuildData</definitionname>
+			<classname>wcf\system\worker\ConversationMessageSearchIndexRebuildDataWorker</classname>
+			<nicevalue>121</nicevalue>
+		</type>
 		<!-- /rebuild data workers -->
 		<!-- stat handlers -->
 		<type>


### PR DESCRIPTION
This also fixes a bug within the indexing process: Previously each message
within a conversation would have been assigned the conversation's subject as
the subject, while the regular creation process does not.

Fix this by only setting the title for the first message within the
conversation.

Resolves #160
