### PR TITLE
Fix calculation of `lastMessageID` when removing other conversation participants

### DIFF
--- a/files/lib/data/conversation/ConversationEditor.class.php
+++ b/files/lib/data/conversation/ConversationEditor.class.php
@@ -171,7 +171,8 @@ class ConversationEditor extends DatabaseObjectEditor {
 			FROM    wcf".WCF_N."_conversation_message
 			WHERE   conversationID = ?
 				AND time >= ?
-				AND time <= ?";
+				AND time <= ?
+			ORDER BY time DESC";
 		$statement = WCF::getDB()->prepareStatement($sql, 1);
 		$statement->execute([
 			$this->conversationID,


### PR DESCRIPTION
Without this `ORDER BY` usually the first visible message would've been set as
the `lastMessageID`, as that's the first row within the `conversation_message`
table.
