### PR TITLE
Fix conversation order when being removed from conversation

### DIFF
--- a/files/lib/data/conversation/UserConversationList.class.php
+++ b/files/lib/data/conversation/UserConversationList.class.php
@@ -103,7 +103,13 @@ class UserConversationList extends ConversationList
                     AND conversation_to_user.conversationID = conversation.conversationID";
 
         if ($this->filter !== 'draft') {
-            $this->sqlSelects .= ", conversation.*, CASE WHEN conversation_to_user.leftAt <> 0 THEN conversation_to_user.leftAt ELSE conversation.lastPostTime END AS lastPostTime";
+            $this->sqlSelects .= ",
+            conversation.*,
+            (CASE
+                WHEN    conversation_to_user.leftAt <> 0
+                THEN    conversation_to_user.leftAt
+                ELSE    conversation.lastPostTime
+            END) AS lastPostTime";
             // this avoids appending `conversation.*` to the SELECT list
             $this->useQualifiedShorthand = false;
         }
@@ -151,7 +157,11 @@ class UserConversationList extends ConversationList
         }
 
         $sql = "SELECT  conversation_to_user.conversationID AS objectID,
-                        CASE WHEN conversation_to_user.leftAt <> 0 THEN conversation_to_user.leftAt ELSE conversation.lastPostTime END AS lastPostTime
+                        (CASE
+                            WHEN    conversation_to_user.leftAt <> 0
+                            THEN    conversation_to_user.leftAt
+                            ELSE    conversation.lastPostTime
+                        END) AS lastPostTime
                 FROM    wcf" . WCF_N . "_conversation_to_user conversation_to_user
                     " . $this->sqlConditionJoins . "
                     " . $this->getConditionBuilder() . "

--- a/files/lib/data/conversation/UserConversationList.class.php
+++ b/files/lib/data/conversation/UserConversationList.class.php
@@ -150,7 +150,8 @@ class UserConversationList extends ConversationList
             return;
         }
 
-        $sql = "SELECT  conversation_to_user.conversationID AS objectID
+        $sql = "SELECT  conversation_to_user.conversationID AS objectID,
+                        CASE WHEN conversation_to_user.leftAt <> 0 THEN conversation_to_user.leftAt ELSE conversation.lastPostTime END AS lastPostTime
                 FROM    wcf" . WCF_N . "_conversation_to_user conversation_to_user
                     " . $this->sqlConditionJoins . "
                     " . $this->getConditionBuilder() . "


### PR DESCRIPTION
When one is removed from a conversation, UserConversationList will use the time
of removal as the conversation's `lastPostTime` when ordering, instead of the
actual time of the newest message to not leak information about new messages
after removal.

However this was not properly accounted for within `readObjectIDs()`. Now if a
conversation one was removed from receives new messages after a long-ish time -
with several conversations in between - the conversation will appear on the
*pageNo* where it would be if one would still be a participant. But within the
page it would be ordered based on the timestamp of removal (i.e. appear at the
very bottom of the page).

Fix this by also overriding `lastPostTime` in `readObjectIDs()`. This will move
the conversation to the proper `pageNo` based on the removal time.

This might still be slightly misleading, because the “last message” column in
the template shows the time of the actual last visible message, but this
confusion can be resolved by opening the conversation and seeing the removal
timestamp matching up, whereas without this fix the conversation can be all
over the place.
