### PR TITLE
Add fallback for conversations without messages

### DIFF
--- a/files/lib/data/conversation/ConversationAction.class.php
+++ b/files/lib/data/conversation/ConversationAction.class.php
@@ -490,6 +490,12 @@ class ConversationAction extends AbstractDatabaseObjectAction implements
             ->add("conversation_message.messageID = ?", [$this->conversation->firstMessageID]);
         $messageList->readObjects();
 
+        if (!\count($messageList)) {
+            return [
+                'template' => '',
+            ];
+        }
+
         return [
             'template' => WCF::getTPL()->fetch('conversationMessagePreview', 'wcf', [
                 'message' => $messageList->getSingleObject(),

--- a/files/lib/page/ConversationPage.class.php
+++ b/files/lib/page/ConversationPage.class.php
@@ -275,10 +275,10 @@ class ConversationPage extends MultipleLinkPage
 
         // get timeframe for modifications
         $this->objectList->rewind();
-        $startTime = ($this->conversation->joinedAt ?: $this->objectList->current()->time);
+        $count = \count($this->objectList);
+        $startTime = ($this->conversation->joinedAt ?: ($count ? $this->objectList->current()->time : $this->conversation->time));
         $endTime = ($this->conversation->leftAt ?: TIME_NOW);
 
-        $count = \count($this->objectList);
         if ($count > 1) {
             $this->objectList->seek($count - 1);
             if ($this->objectList->current()->time < $this->conversation->lastPostTime) {


### PR DESCRIPTION
Conversations that did not contain any messages for any reason could not be opened and therefore could not be left / deleted.

ref https://www.woltlab.com/community/thread/295961-fehler-in-den-konversationen/