### PR TITLE
Fix Conversation::hasOtherParticipants()

### DIFF
--- a/files/lib/data/conversation/Conversation.class.php
+++ b/files/lib/data/conversation/Conversation.class.php
@@ -411,39 +411,16 @@ class Conversation extends DatabaseObject implements IPopoverObject, IRouteContr
      */
     public function hasOtherParticipants()
     {
-        if ($this->userID == WCF::getUser()->userID) {
-            // author
-            if ($this->participants == 0) {
-                return false;
-            }
+        $participantList = new ConversationParticipantList(
+            $this->conversationID,
+            WCF::getUser()->userID,
+            $this->userID == WCF::getUser()->userID
+        );
+        $participantList->getConditionBuilder()->add('conversation_to_user.hideConversation <> ?', [self::STATE_LEFT]);
+        $participantList->getConditionBuilder()->add('conversation_to_user.leftAt = ?', [0]);
+        $participantList->readObjectIDs();
 
-            return true;
-        } else {
-            if ($this->participants > 1) {
-                return true;
-            }
-            if ($this->isInvisible && $this->participants > 0) {
-                return true;
-            }
-
-            if ($this->userID) {
-                // check if author has left the conversation
-                $sql = "SELECT  hideConversation
-                        FROM    wcf" . WCF_N . "_conversation_to_user
-                        WHERE   conversationID = ?
-                            AND participantID = ?";
-                $statement = WCF::getDB()->prepareStatement($sql);
-                $statement->execute([$this->conversationID, $this->userID]);
-                $row = $statement->fetchArray();
-                if ($row !== false) {
-                    if ($row['hideConversation'] != self::STATE_LEFT) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
+        return \count($participantList->getObjectIDs()) > 1;
     }
 
     /**


### PR DESCRIPTION
The previous implementation did not correctly handle invisible participants,
because they are not included in the participant counter.

It has been verified that the warning correctly shows when all other
participants are invisible and the creator as the only visible participant
left.

see https://www.woltlab.com/community/thread/301790/
