### PR TITLE
Fix adding participants that previously participated invisibly

### DIFF
--- a/files/lib/data/conversation/ConversationEditor.class.php
+++ b/files/lib/data/conversation/ConversationEditor.class.php
@@ -85,6 +85,7 @@ class ConversationEditor extends DatabaseObjectEditor
                     VALUES      (?, ?, ?, ?, ?)
                     ON DUPLICATE KEY
                     UPDATE      hideConversation = 0,
+                                isInvisible = 0,
                                 leftAt = 0,
                                 leftByOwnChoice = 1";
             $statement = WCF::getDB()->prepareStatement($sql);


### PR DESCRIPTION
Adding participants after-the-fact is only allowed with visible participants.
However the case of an invisible participant being re-added after previously
being removed was not correctly handled: The participant remained invisible,
but a log message about them being added was created.
