### PR TITLE
Fix opening draft conversations

### DIFF
--- a/files/lib/page/ConversationPage.class.php
+++ b/files/lib/page/ConversationPage.class.php
@@ -303,6 +303,11 @@ class ConversationPage extends MultipleLinkPage
             }
         }
 
+        // Drafts do not store their participants in conversation_to_user.
+        if ($this->conversation->isDraft) {
+            $visibleParticipantIDs[] = $this->conversation->userID;
+        }
+
         // load modification log entries
         $this->modificationLogList = new ConversationLogModificationLogList($this->conversation->conversationID);
         $this->modificationLogList->getConditionBuilder()


### PR DESCRIPTION
This got broken in 40edd0891d0003c5441dfd2c067eeb5632fbc2ed, because drafts do
not have any participants, thus resulting in an empty list of visible
participants, breaking the database query for the modification log.

Fix this by adding the conversation author to the array if it's a draft
conversation. They are able to see it by definition.
