### PR TITLE
Load embedded content when moderation entries are displayed

### DIFF
--- a/files/lib/system/moderation/queue/report/ConversationMessageModerationQueueReportHandler.class.php
+++ b/files/lib/system/moderation/queue/report/ConversationMessageModerationQueueReportHandler.class.php
@@ -97,9 +97,8 @@ class ConversationMessageModerationQueueReportHandler extends AbstractModeration
      */
     public function getReportedContent(ViewableModerationQueue $queue)
     {
-        /** @noinspection PhpParamsInspection */
         WCF::getTPL()->assign([
-            'message' => new ViewableConversationMessage($queue->getAffectedObject()),
+            'message' => ViewableConversationMessage::getViewableConversationMessage($queue->objectID),
         ]);
 
         return WCF::getTPL()->fetch('moderationConversationMessage');


### PR DESCRIPTION
Embedded content such as attachments are currently not displayed correctly on the moderation page