### PR TITLE
Refactor templates

### DIFF
--- a/files/lib/data/conversation/ConversationAction.class.php
+++ b/files/lib/data/conversation/ConversationAction.class.php
@@ -144,7 +144,8 @@ class ConversationAction extends AbstractDatabaseObjectAction implements
             );
         }
 
-        return $conversation;
+        // Reload the object so that `firstMessageID` is set.
+        return new Conversation($conversation->conversationID);
     }
 
     /**

--- a/templates/__userInformationStartConversation.tpl
+++ b/templates/__userInformationStartConversation.tpl
@@ -1,6 +1,6 @@
 {if MODULE_CONVERSATION && $__wcf->user->userID && $__wcf->session->getPermission('user.conversation.canUseConversation') && $__wcf->session->getPermission('user.conversation.canStartConversation') && $user->userID != $__wcf->user->userID}
 	<li>
-		<a class="jsTooltip" href="{link controller='ConversationAdd'}userID={@$user->userID}{/link}" title="{lang}wcf.conversation.button.add{/lang}">
+		<a class="jsTooltip" href="{link controller='ConversationAdd' userID=$user->userID}{/link}" title="{lang}wcf.conversation.button.add{/lang}">
 			{icon name='comments' type='solid'}
 			<span class="invisible">{lang}wcf.conversation.button.add{/lang}</span>
 		</a>

--- a/templates/__userPanelConversationDropdown.tpl
+++ b/templates/__userPanelConversationDropdown.tpl
@@ -16,7 +16,7 @@
 			{/if}
 		</a>
 		{if !OFFLINE || $__wcf->session->getPermission('admin.general.canViewPageDuringOfflineMode')}
-			<script data-relocate="true" src="{$__wcf->getPath()}js/WCF.Conversation{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={@LAST_UPDATE_TIME}"></script>
+			<script data-relocate="true" src="{$__wcf->getPath()}js/WCF.Conversation{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={LAST_UPDATE_TIME}"></script>
 			<script data-relocate="true">
 				require(["WoltLabSuite/Core/Conversation/Ui/User/Menu/Data/Conversation"], ({ setup }) => {
 					setup({

--- a/templates/conversationAdd.tpl
+++ b/templates/conversationAdd.tpl
@@ -17,7 +17,7 @@
 						{elseif $errorType == 'censoredWordsFound'}
 							{lang}wcf.message.error.censoredWordsFound{/lang}
 						{else}
-							{lang}wcf.conversation.subject.error.{@$errorType}{/lang}
+							{lang}wcf.conversation.subject.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -40,10 +40,10 @@
 							{lang}wcf.global.form.error.empty{/lang}
 						{elseif $errorType|is_array}
 							{foreach from=$errorType item='errorData'}
-								{lang}wcf.conversation.participants.error.{@$errorData.type}{/lang}
+								{lang}wcf.conversation.participants.error.{$errorData.type}{/lang}
 							{/foreach}
 						{else}
-							{lang}wcf.conversation.participants.error.{@$errorType}{/lang}
+							{lang}wcf.conversation.participants.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -62,10 +62,10 @@
 								{lang}wcf.global.form.error.empty{/lang}
 							{elseif $errorType|is_array}
 								{foreach from=$errorType item='errorData'}
-									{lang}wcf.conversation.participants.error.{@$errorData.type}{/lang}
+									{lang}wcf.conversation.participants.error.{$errorData.type}{/lang}
 								{/foreach}
 							{else}
-								{lang}wcf.conversation.participants.error.{@$errorType}{/lang}
+								{lang}wcf.conversation.participants.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -108,7 +108,7 @@
 						{elseif $errorType == 'disallowedBBCodes'}
 							{lang}wcf.message.error.disallowedBBCodes{/lang}
 						{else}
-							{lang}wcf.conversation.message.error.{@$errorType}{/lang}
+							{lang}wcf.conversation.message.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -133,14 +133,14 @@
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/ItemList/User'], function(UiItemListUser) {
 		UiItemListUser.init('participants', {
-			maxItems: {@$__wcf->getSession()->getPermission('user.conversation.maxParticipants')},
+			maxItems: {$__wcf->getSession()->getPermission('user.conversation.maxParticipants')},
 			includeUserGroups: {if $__wcf->getSession()->getPermission('user.conversation.canAddGroupParticipants')}true{else}false{/if},
-			restrictUserGroupIDs: [-1, {implode from=$allowedUserGroupIDs item=allowedUserGroupID}{@$allowedUserGroupID}{/implode}],
+			restrictUserGroupIDs: [-1, {implode from=$allowedUserGroupIDs item=allowedUserGroupID}{$allowedUserGroupID}{/implode}],
 			csvPerType: true,
 			callbackSetupValues: function() {
 				return [
 					{implode from=$participantsData item=participant}
-						{ objectId: {@$participant['objectId']}, value: '{@$participant['value']|encodeJS}', type: '{@$participant['type']}' }
+						{ objectId: {$participant['objectId']}, value: '{unsafe:$participant['value']|encodeJS}', type: '{unsafe:$participant['type']|encodeJS}' }
 					{/implode}
 				];
 			}
@@ -148,14 +148,14 @@
 		
 		{if $__wcf->session->getPermission('user.conversation.canAddInvisibleParticipants')}
 			UiItemListUser.init('invisibleParticipants', {
-				maxItems: {@$__wcf->getSession()->getPermission('user.conversation.maxParticipants')},
+				maxItems: {$__wcf->getSession()->getPermission('user.conversation.maxParticipants')},
 				includeUserGroups: {if $__wcf->getSession()->getPermission('user.conversation.canAddGroupParticipants')}true{else}false{/if},
-				restrictUserGroupIDs: [-1, {implode from=$allowedUserGroupIDs item=allowedUserGroupID}{@$allowedUserGroupID}{/implode}],
+				restrictUserGroupIDs: [-1, {implode from=$allowedUserGroupIDs item=allowedUserGroupID}{$allowedUserGroupID}{/implode}],
 				csvPerType: true,
 				callbackSetupValues: function() {
 					return [
 						{implode from=$invisibleParticipantsData item=participant}
-							{ objectId: {@$participant['objectId']}, value: '{@$participant['value']|encodeJS}', type: '{@$participant['type']}' }
+							{ objectId: {$participant['objectId']}, value: '{unsafe:$participant['value']|encodeJS}', type: '{unsafe:$participant['type']|encodeJS}' }
 						{/implode}
 					];
 				}

--- a/templates/conversationList.tpl
+++ b/templates/conversationList.tpl
@@ -27,7 +27,7 @@
 {/capture}
 
 {capture assign='headContent'}
-	<link rel="alternate" type="application/rss+xml" title="{lang}wcf.global.button.rss{/lang}" href="{link controller='ConversationRssFeed'}at={@$__wcf->getUser()->userID}-{@$__wcf->getUser()->accessToken}{/link}">
+	<link rel="alternate" type="application/rss+xml" title="{lang}wcf.global.button.rss{/lang}" href="{link controller='ConversationRssFeed'}at={$__wcf->getUser()->userID}-{$__wcf->getUser()->accessToken}{/link}">
 {/capture}
 
 {capture assign='sidebarRight'}
@@ -58,7 +58,7 @@
 		<h2 class="boxTitle">{lang}wcf.conversation.filter.participants{/lang}</h2>
 		
 		<div class="boxContent">
-			<form action="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}{/link}" method="post">
+			<form action="{link controller='ConversationList' sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo}{if $filter}filter={$filter}{/if}{/link}" method="post">
 				<dl>
 					<dt></dt>
 					<dd><label><textarea id="participants" name="participants" class="long">{implode from=$participants item=participant glue=','}{$participant}{/implode}</textarea></label></dd>
@@ -92,12 +92,12 @@
 				<div class="dropdownMenu">
 					<ul class="scrollableDropdownMenu">
 						{foreach from=$labelList item=label}
-							<li><a href="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}&labelID={@$label->labelID}{/link}"><span class="badge label{if $label->cssClassName} {@$label->cssClassName}{/if}" data-css-class-name="{if $label->cssClassName}{@$label->cssClassName}{/if}" data-label-id="{$label->labelID}">{$label->label}</span></a></li>
+							<li><a href="{link controller='ConversationList' sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo labelID=$label->labelID}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}{/if}{/link}"><span class="badge label{if $label->cssClassName} {$label->cssClassName}{/if}" data-css-class-name="{if $label->cssClassName}{$label->cssClassName}{/if}" data-label-id="{$label->labelID}">{$label->label}</span></a></li>
 						{/foreach}
 					</ul>
 					<ul>
 						<li class="dropdownDivider"{if !$labelList|count} style="display: none;"{/if}></li>
-						<li><a href="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}{/link}"><span class="badge label">{lang}wcf.conversation.label.disableFilter{/lang}</span></a></li>
+						<li><a href="{link controller='ConversationList' sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}{/if}{/link}"><span class="badge label">{lang}wcf.conversation.label.disableFilter{/lang}</span></a></li>
 					</ul>
 				</div>
 			</div>
@@ -146,7 +146,7 @@
 {/capture}
 
 {capture assign='contentInteractionDropdownItems'}
-	<li><a rel="alternate" href="{link controller='ConversationRssFeed'}at={@$__wcf->getUser()->userID}-{@$__wcf->getUser()->accessToken}{/link}">{lang}wcf.global.button.rss{/lang}</a></li>
+	<li><a rel="alternate" href="{link controller='ConversationRssFeed'}at={$__wcf->getUser()->userID}-{$__wcf->getUser()->accessToken}{/link}">{lang}wcf.global.button.rss{/lang}</a></li>
 {/capture}
 
 {include file='header'}
@@ -163,7 +163,7 @@
 					<li class="columnSort">
 						<ul class="inlineList">
 							<li>
-								<a rel="nofollow" href="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}pageNo={@$pageNo}&sortField={$sortField}&sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $labelID}&labelID={@$labelID}{/if}{/link}">
+								<a rel="nofollow" href="{link controller='ConversationList' pageNo=$pageNo sortField=$sortField}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}&{/if}sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $labelID}&labelID={$labelID}{/if}{/link}">
 									{if $sortOrder === 'ASC'}
 										<span class="jsTooltip" title="{lang}wcf.global.sorting{/lang} ({lang}wcf.global.sortOrder.ascending{/lang})">
 											{icon name='arrow-down-wide-short'}
@@ -181,7 +181,7 @@
 									
 									<ul class="dropdownMenu">
 										{foreach from=$validSortFields item=_sortField}
-											<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}pageNo={@$pageNo}&sortField={$_sortField}&sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $labelID}&labelID={@$labelID}{/if}{/link}">{if $_sortField == 'subject'}{lang}wcf.global.subject{/lang}{else}{lang}wcf.conversation.{$_sortField}{/lang}{/if}</a></li>
+											<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='ConversationList' pageNo=$pageNo sortField=$_sortField}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}&{/if}sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $labelID}&labelID={$labelID}{/if}{/link}">{if $_sortField == 'subject'}{lang}wcf.global.subject{/lang}{else}{lang}wcf.conversation.{$_sortField}{/lang}{/if}</a></li>
 										{/foreach}
 									</ul>
 								</div>
@@ -200,11 +200,11 @@
 						<li class="columnIcon columnAvatar">
 							{if $conversation->getUserProfile()->getAvatar()}
 								<div>
-									<p{if $conversation->isNew()} title="{lang}wcf.conversation.markAsRead.doubleClick{/lang}"{/if}>{@$conversation->getUserProfile()->getAvatar()->getImageTag(48)}</p>
+									<p{if $conversation->isNew()} title="{lang}wcf.conversation.markAsRead.doubleClick{/lang}"{/if}>{unsafe:$conversation->getUserProfile()->getAvatar()->getImageTag(48)}</p>
 									
 									{if $conversation->ownPosts && $conversation->userID != $__wcf->user->userID}
 										{if $__wcf->getUserProfileHandler()->getAvatar()}
-											<small class="myAvatar jsTooltip" title="{lang}wcf.conversation.ownPosts{/lang}">{@$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(24)}</small>
+											<small class="myAvatar jsTooltip" title="{lang}wcf.conversation.ownPosts{/lang}">{unsafe:$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(24)}</small>
 										{/if}
 									{/if}
 								</div>
@@ -215,7 +215,7 @@
 								<ul class="labelList">
 									{content}
 										{foreach from=$conversation->getAssignedLabels() item=label}
-											<li><a href="{link controller='ConversationList'}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}&labelID={@$label->labelID}{/link}" class="badge label{if $label->cssClassName} {@$label->cssClassName}{/if}">{$label->label}</a></li>
+											<li><a href="{link controller='ConversationList' sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo labelID=$label->labelID}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}{/if}{/link}" class="badge label{if $label->cssClassName} {$label->cssClassName}{/if}">{$label->label}</a></li>
 										{/foreach}
 									{/content}
 								</ul>
@@ -224,7 +224,7 @@
 							<h3>
 								<a href="{if $conversation->isNew()}{link controller='Conversation' object=$conversation}action=firstNew{/link}{else}{$conversation->getLink()}{/if}" class="conversationLink messageGroupLink" data-object-id="{$conversation->conversationID}">{$conversation->subject}</a>
 								{if $conversation->replies}
-									<span class="badge messageGroupCounterMobile">{@$conversation->replies|shortUnit}</span>
+									<span class="badge messageGroupCounterMobile">{$conversation->replies|shortUnit}</span>
 								{/if}
 							</h3>
 							
@@ -272,11 +272,11 @@
 						<li class="columnStats">
 							<dl class="plain statsDataList">
 								<dt>{lang}wcf.conversation.replies{/lang}</dt>
-								<dd>{@$conversation->replies|shortUnit}</dd>
+								<dd>{$conversation->replies|shortUnit}</dd>
 							</dl>
 							<dl class="plain statsDataList">
 								<dt>{lang}wcf.conversation.participants{/lang}</dt>
-								<dd>{@$conversation->participants|shortUnit}</dd>
+								<dd>{$conversation->participants|shortUnit}</dd>
 							</dl>
 							
 							<div class="messageGroupListStatsSimple">
@@ -284,14 +284,14 @@
 									<span aria-label="{lang}wcf.conversation.replies{/lang}">
 										{icon name='comment'}
 									</span>
-									{@$conversation->replies|shortUnit}
+									{$conversation->replies|shortUnit}
 								{/if}
 							</div>
 						</li>
 						<li class="columnLastPost">
 							{if $conversation->replies != 0 && $conversation->lastPostTime}
 								<div class="box32">
-									<a href="{link controller='Conversation' object=$conversation}action=lastPost{/link}" class="jsTooltip" title="{lang}wcf.conversation.gotoLastPost{/lang}">{@$conversation->getLastPosterProfile()->getAvatar()->getImageTag(32)}</a>
+									<a href="{link controller='Conversation' object=$conversation action='lastPost'}{/link}" class="jsTooltip" title="{lang}wcf.conversation.gotoLastPost{/lang}">{unsafe:$conversation->getLastPosterProfile()->getAvatar()->getImageTag(32)}</a>
 									
 									<div>
 										<p>
@@ -337,7 +337,7 @@
 	{/hascontent}
 </footer>
 
-<script data-relocate="true" src="{$__wcf->getPath()}js/WCF.Conversation{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={@LAST_UPDATE_TIME}"></script>
+<script data-relocate="true" src="{$__wcf->getPath()}js/WCF.Conversation{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={LAST_UPDATE_TIME}"></script>
 <script data-relocate="true">
 	require([
 		'WoltLabSuite/Core/Language',
@@ -373,13 +373,13 @@
 			hasMarkedItems: {if $hasMarkedItems}true{else}false{/if},
 		});
 
-		const availableLabels = [{implode from=$labelList item=label}{ cssClassName: '{if $label->cssClassName}{unsafe:$label->cssClassName|encodeJS}{/if}', labelID: {@$label->labelID}, label: '{$label->label|encodeJS}', url: '{link controller='ConversationList' encode=false}labelID={$label->labelID}{if $filter}&filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}{/link}' }{/implode} ];
+		const availableLabels = [{implode from=$labelList item=label}{ cssClassName: '{if $label->cssClassName}{unsafe:$label->cssClassName|encodeJS}{/if}', labelID: {$label->labelID}, label: '{$label->label|encodeJS}', url: '{link controller='ConversationList' encode=false sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo}labelID={$label->labelID}{if $filter}&filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}{/if}{/link}' }{/implode} ];
 		var $editorHandler = new WCF.Conversation.EditorHandler(availableLabels);
 		var $inlineEditor = new WCF.Conversation.InlineEditor('.conversation');
 		$inlineEditor.setEditorHandler($editorHandler, 'list');
 
 		ConversationClipboard.setup($editorHandler);
-		new LabelManager('{link controller='ConversationLabelForm'}{/link}', '{link controller='ConversationList' encode=false}{if $filter}filter={@$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}&{/if}sortField={$sortField}&sortOrder={$sortOrder}&pageNo={@$pageNo}{/link}');
+		new LabelManager('{link controller='ConversationLabelForm'}{/link}', '{link controller='ConversationList' encode=false sortField=$sortField sortOrder=$sortOrder pageNo=$pageNo}{if $filter}filter={$filter}&{/if}{if !$participants|empty}participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}{/if}{/link}');
 		
 		// mobile safari hover workaround
 		if ($(window).width() <= 800) {

--- a/templates/conversationList.tpl
+++ b/templates/conversationList.tpl
@@ -130,12 +130,18 @@
 	{event name='boxes'}
 {/capture}
 
+{assign var='linkParameters' value=''}
+{if $participants}{capture append='linkParameters'}&participants={implode from=$participants item=participant}{unsafe:$participant|rawurlencode}{/implode}{/capture}{/if}
+{if $labelID}{capture append='linkParameters'}&labelID={$labelID}{/capture}{/if}
+
 {capture assign='contentInteractionPagination'}
-	{assign var='participantsParameter' value=''}
-	{if $participants}{capture assign='participantsParameter'}&participants={implode from=$participants item=participant}{$participant|rawurlencode}{/implode}{/capture}{/if}
-	{assign var='labelIDParameter' value=''}
-	{if $labelID}{assign var='labelIDParameter' value="&labelID=$labelID"}{/if}
-	{pages print=true assign=pagesLinks controller='ConversationList' link="filter=$filter$participantsParameter&pageNo=%d&sortField=$sortField&sortOrder=$sortOrder$labelIDParameter"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='ConversationList' filter=$filter sortField=$sortField sortOrder=$sortOrder}{unsafe:$linkParameters}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {capture assign='contentInteractionButtons'}
@@ -312,11 +318,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='ConversationList' filter=$filter sortField=$sortField sortOrder=$sortOrder}{unsafe:$linkParameters}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 	
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/templates/conversationMessageInlineEditor.tpl
+++ b/templates/conversationMessageInlineEditor.tpl
@@ -1,10 +1,10 @@
-{capture assign='wysiwygSelector'}messageEditor{@$message->messageID}{/capture}
+{capture assign='wysiwygSelector'}messageEditor{$message->messageID}{/capture}
 <div class="messageInlineEditor">
 	<textarea id="{$wysiwygSelector}" class="wysiwygTextarea"
 		data-autosave="com.woltlab.wcf.conversation.messageEdit-{$message->messageID}"
 		data-support-mention="true"
 	>{$text}</textarea>
-	{capture assign=wysiwygContainerID}messageEditor{@$message->messageID}{/capture}
+	{capture assign=wysiwygContainerID}messageEditor{$message->messageID}{/capture}
 	{include file='messageFormTabsInline' inConversationInlineEdit=true wysiwygContainerID=$wysiwygContainerID}
 	
 	<div class="formSubmit">

--- a/templates/conversationMessageListLog.tpl
+++ b/templates/conversationMessageListLog.tpl
@@ -13,7 +13,7 @@
 									{user object=$modificationLogEntry->getUserProfile() class='username'}
 									<small class="separatorLeft">{time time=$modificationLogEntry->time}</small>
 								</h2>
-								<div>{@$modificationLogEntry}</div>
+								<div>{unsafe:$modificationLogEntry}</div>
 							</div>
 						</div>
 					</div>

--- a/templates/email_notification_conversation.tpl
+++ b/templates/email_notification_conversation.tpl
@@ -1,7 +1,7 @@
 {if $mimeType === 'text/plain'}
 {lang}wcf.user.notification.conversation.mail.plaintext{/lang}
 
-{@$event->getUserNotificationObject()->getFirstMessage()->getMailText($mimeType)} {* this line ends with a space *}
+{unsafe:$event->getUserNotificationObject()->getFirstMessage()->getMailText($mimeType)} {* this line ends with a space *}
 {else}
 	{lang}wcf.user.notification.conversation.mail.html{/lang}
 	{assign var='user' value=$event->getAuthor()}
@@ -13,7 +13,7 @@
 	{capture assign='messageContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$message->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$message->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -27,7 +27,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$message->getMailText($mimeType)}
+					{unsafe:$message->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/templates/email_notification_conversationMessage.tpl
+++ b/templates/email_notification_conversationMessage.tpl
@@ -3,7 +3,7 @@
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
 {lang}wcf.user.notification.conversation.message.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered}
 
-{@$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
+{unsafe:$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
 	{lang}wcf.user.notification.conversation.message.mail.html{/lang}
@@ -16,7 +16,7 @@
 	{capture assign='messageContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$message->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$message->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -30,7 +30,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$message->getMailText($mimeType)}
+					{unsafe:$message->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/templates/moderationConversationMessage.tpl
+++ b/templates/moderationConversationMessage.tpl
@@ -23,7 +23,7 @@
 			{event name='beforeMessageText'}
 			
 			<div class="messageText">
-				{@$message->getFormattedMessage()}
+				{unsafe:$message->getFormattedMessage()}
 			</div>
 			
 			{event name='afterMessageText'}

--- a/templates/userCard_buttons_conversationButton.tpl
+++ b/templates/userCard_buttons_conversationButton.tpl
@@ -1,3 +1,3 @@
 {if MODULE_CONVERSATION && $__wcf->user->userID && $__wcf->session->getPermission('user.conversation.canUseConversation') && $__wcf->session->getPermission('user.conversation.canStartConversation') && $user->userID != $__wcf->user->userID}
-	<a class="userCard__button jsTooltip" href="{link controller='ConversationAdd'}userID={@$user->userID}{/link}" title="{lang}wcf.conversation.button.add{/lang}">{icon name='comments' type='solid' size=24}</a>
+	<a class="userCard__button jsTooltip" href="{link controller='ConversationAdd' userID=$user->userID}{/link}" title="{lang}wcf.conversation.button.add{/lang}">{icon name='comments' type='solid' size=24}</a>
 {/if}


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated `{pages}` with `<woltlab-core-pagination>`
- Fixes the issue where the notification test for **New Conversation** was not functioning properly